### PR TITLE
CEXT-4966: Fixing jsdoc for out pipeline stage

### DIFF
--- a/lib/AggregateCursor.js
+++ b/lib/AggregateCursor.js
@@ -104,7 +104,7 @@ class AggregateCursor extends AbstractDbCursor {
   /**
    * Add an $out stage to the aggregation pipeline.
    *
-   * @param {(Object|string)} outSpec
+   * @param {string} outSpec
    * @returns {this}
    */
   out(outSpec) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The $out pipeline stage accepts only a string in DocumentDB and not an object

See also: https://git.corp.adobe.com/core-commerce-saas/ab-dbproxy-service/pull/113
<!--- Describe your changes in detail -->

## Related Issue

[CEXT-4966: Review and remove aggregation pipeline stages unsupported by DocumentDB](https://jira.corp.adobe.com/browse/CEXT-4966)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
