### PR TITLE
CEXT-5102: Fixing jsdoc for db.ping()

### DIFF
--- a/lib/DbBase.js
+++ b/lib/DbBase.js
@@ -102,7 +102,7 @@ class DbBase {
   /**
    * General connectivity check with App Builder Database Service
    *
-   * @returns {Promise<string>} ping results
+   * @returns {Promise<Object>} ping results
    * @throws {DbError}
    * @memberof DbBase
    */

--- a/lib/api/db.js
+++ b/lib/api/db.js
@@ -64,7 +64,7 @@ async function provisionStatus(db) {
  * Checks connectivity with the App Builder Database Service
  *
  * @param {DbBase} db
- * @returns {Promise<string>}
+ * @returns {Promise<Object>}
  * @throws {DbError}
  */
 async function ping(db) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The jsdoc for `db.ping()` now correctly denotes that the return value is the object from the API response

See also: https://git.corp.adobe.com/CNA/adp-storage-database/pull/24

## Related Issue

[CEXT-5102: Public /v1/db/ping endpoint revision](https://jira.corp.adobe.com/browse/CEXT-5102)

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Jsdoc correctness is crucial for proper typehinting
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Doc comment update only, no tests needed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
