### PR TITLE
CEXT-5334: Removing runtime endpoint from stage

### DIFF
--- a/lib/DbBase.js
+++ b/lib/DbBase.js
@@ -14,7 +14,9 @@ const { pingApi, provisionStatusApi, provisionRequestApi, deleteDatabaseApi } = 
 const DbClient = require('./DbClient')
 const DbError = require("./DbError")
 const { getAxiosClient } = require("../utils/axiosUtils")
-const { ALLOWED_REGIONS, ENDPOINTS, EXECUTION_CONTEXT } = require("./constants")
+const {
+  ALLOWED_REGIONS, STAGE_ENV, STAGE_ENDPOINT, PROD_ENDPOINT_RUNTIME, PROD_ENDPOINT_EXTERNAL
+} = require("./constants")
 const { getCliEnv } = require("@adobe/aio-lib-env")
 
 class DbBase {
@@ -45,11 +47,27 @@ class DbBase {
       throw new DbError(`Invalid region '${region}' for the ${env} environment, must be one of: ${validRegions.join(', ')}`)
     }
 
-    // If __OW_ACTIVATION_ID is set, use the internal runtime action endpoint, otherwise use the external endpoint
-    const context = process.env.__OW_ACTIVATION_ID ? EXECUTION_CONTEXT.RUNTIME : EXECUTION_CONTEXT.EXTERNAL
-
+    let serviceUrl
     // Allow overriding service URL via environment variable for testing
-    this.serviceUrl = process.env.AIO_DB_ENDPOINT || ENDPOINTS[context][env].replaceAll(/<region>/gi, this.region)
+    if (process.env.AIO_DB_ENDPOINT) {
+      serviceUrl = process.env.AIO_DB_ENDPOINT
+    }
+    else {
+      if (env === STAGE_ENV) {
+        // Stage environment does not have a separate runtime endpoint
+        serviceUrl = STAGE_ENDPOINT
+      }
+      else if (process.env.__OW_ACTIVATION_ID) {
+        // If __OW_ACTIVATION_ID is set, the sdk is being used from inside a runtime action
+        serviceUrl = PROD_ENDPOINT_RUNTIME
+      }
+      else {
+        serviceUrl = PROD_ENDPOINT_EXTERNAL
+      }
+      serviceUrl = serviceUrl.replaceAll(/<region>/gi, this.region)
+    }
+
+    this.serviceUrl = serviceUrl
     this.axiosClient = getAxiosClient()
   }
 

--- a/lib/__mocks__/constants.js
+++ b/lib/__mocks__/constants.js
@@ -15,14 +15,7 @@ const constants = jest.requireActual('../constants')
 // Set the endpoints to known test URLs
 module.exports = {
   ...constants,
-  ENDPOINTS: {
-    [constants.EXECUTION_CONTEXT.RUNTIME]: {
-      [constants.PROD_ENV]: 'https://db.<region>.int.adobe.test',
-      [constants.STAGE_ENV]: 'https://db-stg.<region>.int.adobe.test'
-    },
-    [constants.EXECUTION_CONTEXT.EXTERNAL]: {
-      [constants.PROD_ENV]: 'https://db.<region>.adobe.test',
-      [constants.STAGE_ENV]: 'https://db-stg.<region>.adobe.test'
-    }
-  }
+  STAGE_ENDPOINT: 'https://db-stg.<region>.adobe.test',
+  PROD_ENDPOINT_RUNTIME: 'https://db.<region>.int.adobe.test',
+  PROD_ENDPOINT_EXTERNAL: 'https://db.<region>.adobe.test'
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -25,24 +25,9 @@ const ALLOWED_REGIONS = {
   [STAGE_ENV]: ['amer', 'amer2']
 }
 
-// Enum for whether the SDK is running in an Adobe Runtime action (RUNTIME) or otherwise (EXTERNAL)
-// This affects which set of service endpoints to use
-// Determined by whether the __OW_ACTIVATION_ID getter returns a value
-const EXECUTION_CONTEXT = {
-  RUNTIME: 'runtime',
-  EXTERNAL: 'external'
-}
-
-const ENDPOINTS = {
-  [EXECUTION_CONTEXT.RUNTIME]: {
-    [PROD_ENV]: 'https://storage-database-<region>.app-builder.int.adp.adobe.io',
-    [STAGE_ENV]: 'https://storage-database-<region>.stg.app-builder.int.adp.adobe.io'
-  },
-  [EXECUTION_CONTEXT.EXTERNAL]: {
-    [PROD_ENV]: 'https://storage-database-<region>.app-builder.adp.adobe.io',
-    [STAGE_ENV]: 'https://storage-database-<region>.stg.app-builder.adp.adobe.io'
-  }
-}
+const STAGE_ENDPOINT = 'https://storage-database-<region>.stg.app-builder.adp.adobe.io'
+const PROD_ENDPOINT_RUNTIME = 'https://storage-database-<region>.app-builder.int.adp.adobe.io'
+const PROD_ENDPOINT_EXTERNAL = 'https://storage-database-<region>.app-builder.adp.adobe.io'
 
 module.exports = {
   RUNTIME_HEADER,
@@ -51,6 +36,7 @@ module.exports = {
   PROD_ENV,
   STAGE_ENV,
   ALLOWED_REGIONS,
-  EXECUTION_CONTEXT,
-  ENDPOINTS
+  STAGE_ENDPOINT,
+  PROD_ENDPOINT_RUNTIME,
+  PROD_ENDPOINT_EXTERNAL
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1850,7 +1849,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4698,7 +4696,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "tldts": "^6.1.32"
       },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Internal endpoint is not applicable for stage environment, so remove it.

## Related Issue

[CEXT-5334: Enable access to internal endpoint from deployed runtime actions](https://jira.corp.adobe.com/browse/CEXT-5334)

## Motivation and Context

Runtime actions from developer-stage.adobe.com still deploy to a production runtime environment, which cannot access the internal stage endpoint, so when running in stage all requests should use the external endpoint.

## How Has This Been Tested?

Unit and manual tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
