### PR TITLE
Update axios dependency to >=1.15.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/aio-lib-db",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An abstraction on top of Document DB storage",
   "main": "index.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-logging": "^3.0.2",
     "@adobe/aio-lib-env": "^3.0.1",
-    "axios": ">=1.15.0",
+    "axios": "^1.15.0",
     "bson": "^6.10.3",
     "dotenv": "^17.0.0",
     "http-cookie-agent": "^6.0.8",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@adobe/aio-lib-core-logging": "^3.0.2",
     "@adobe/aio-lib-env": "^3.0.1",
-    "axios": ">=1.8.4 <1.14.1 || ^1.14.2",
+    "axios": ">=1.15.0",
     "bson": "^6.10.3",
     "dotenv": "^17.0.0",
     "http-cookie-agent": "^6.0.8",


### PR DESCRIPTION
Fixes #80

## Summary
- Simplifies the axios version constraint from `>=1.8.4 <1.14.1 || ^1.14.2` to `>=1.15.0`
- Removes the complex exclusion range that was working around older vulnerabilities, favouring a clean minimum version instead

## Test plan
- [x] Verify `npm install` resolves axios at 1.15.0 or newer
- [x] Run existing test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)